### PR TITLE
Add ruby interfaces for ISSN methods

### DIFF
--- a/ext/library_standard_numbers/src/lib.rs
+++ b/ext/library_standard_numbers/src/lib.rs
@@ -1,6 +1,7 @@
 use magnus::{function, prelude::*, Error, RModule, Ruby};
 use library_stdnums::lccn::LCCN;
 use library_stdnums::isbn::ISBN;
+use library_stdnums::issn::ISSN;
 use library_stdnums::traits::{Normalize, Valid};
 
 fn lccn_validate(identifier: String) -> bool {
@@ -18,11 +19,21 @@ fn isbn_validate(identifier: String) -> bool {
 fn isbn_normalize(identifier: String) -> Option<String> {
     ISBN::new(identifier).normalize()
 }
+
+fn issn_validate(identifier: String) -> bool {
+    ISSN::new(identifier).valid()
+}
+
+fn issn_normalize(identifier: String) -> Option<String> {
+    ISSN::new(identifier).normalize()
+}
+
 #[magnus::init]
 fn init(ruby: &Ruby) -> Result<(), Error> {
     let module = ruby.define_module("LibraryStandardNumbers")?;
     create_lccn_module(&module)?;
-    create_isbn_module(&module)?;  
+    create_isbn_module(&module)?;
+    create_issn_module(&module)?;
 
     Ok(())
 }
@@ -39,6 +50,14 @@ fn create_isbn_module(module: &RModule) -> Result<(), Error> {
     let isbn_module = module.define_module("ISBN")?;
     isbn_module.define_singleton_method("valid?", function!(isbn_validate, 1))?;
     isbn_module.define_singleton_method("normalize", function!(isbn_normalize, 1))?;
+
+    Ok(())
+}
+
+fn create_issn_module(module: &RModule) -> Result<(), Error> {
+    let isbn_module = module.define_module("ISSN")?;
+    isbn_module.define_singleton_method("valid?", function!(issn_validate, 1))?;
+    isbn_module.define_singleton_method("normalize", function!(issn_normalize, 1))?;
 
     Ok(())
 }

--- a/spec/isbn_spec.rb
+++ b/spec/isbn_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe LibraryStandardNumbers::ISBN do
+  it "normalizes ISBNs" do
+    expect(LibraryStandardNumbers::ISBN.normalize("0-306-40615-2")).to eq "9780306406157"
+  end
+  it "returns nil when attempting to normalize an invalid ISBN" do
+    expect(LibraryStandardNumbers::ISBN.normalize("na078-890351")).to be_nil
+  end
+  it "validates ISBNs" do
+    expect(LibraryStandardNumbers::ISBN.valid?("9781449373320")).to be true
+  end
+end

--- a/spec/issn_spec.rb
+++ b/spec/issn_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe LibraryStandardNumbers::ISSN do
+  it "validates ISSNs" do
+    expect(LibraryStandardNumbers::ISSN.valid?("0378-5955")).to be true
+    expect(LibraryStandardNumbers::ISSN.valid?("XXXX-XXXX")).to be false
+  end
+  it "normalizes ISSNs" do
+    expect(LibraryStandardNumbers::ISSN.normalize("0378-5955")).to eq "03785955"
+  end
+  it "returns nil when attempting to normalize an invalid ISSN" do
+    expect(LibraryStandardNumbers::ISSN.normalize("XXXX-XXXX")).to be_nil
+  end
+end

--- a/spec/lccn_spec.rb
+++ b/spec/lccn_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe LibraryStandardNumbers::LCCN do
+  it "validates LCCNs" do
+    expect(LibraryStandardNumbers::LCCN.valid?("n78-890351")).to be true
+    expect(LibraryStandardNumbers::LCCN.valid?("n78-89035100444")).to be false
+  end
+  it "normalizes LCCNs" do
+    expect(LibraryStandardNumbers::LCCN.normalize("n  78890351 ")).to eq "n78890351"
+  end
+  it "returns nil when attempting to normalize an invalid LCCN" do
+    expect(LibraryStandardNumbers::LCCN.normalize("na078-890351")).to be_nil
+  end
+end

--- a/spec/library_standard_numbers_spec.rb
+++ b/spec/library_standard_numbers_spec.rb
@@ -4,24 +4,4 @@ RSpec.describe LibraryStandardNumbers do
   it "has a version number" do
     expect(LibraryStandardNumbers::VERSION).not_to be nil
   end
-
-  it "validates LCCNs" do
-    expect(LibraryStandardNumbers::LCCN.valid?("n78-890351")).to be true
-    expect(LibraryStandardNumbers::LCCN.valid?("n78-89035100444")).to be false
-  end
-  it "normalizes LCCNs" do
-    expect(LibraryStandardNumbers::LCCN.normalize("n  78890351 ")).to eq "n78890351"
-  end
-  it "returns nil when attempting to normalize an invalid LCCN" do
-    expect(LibraryStandardNumbers::LCCN.normalize("na078-890351")).to be_nil
-  end
-  it "normalizes ISBNs" do
-    expect(LibraryStandardNumbers::ISBN.normalize("0-306-40615-2")).to eq "9780306406157"
-  end
-  it "returns nil when attempting to normalize an invalid ISBN" do
-    expect(LibraryStandardNumbers::ISBN.normalize("na078-890351")).to be_nil
-  end
-  it "validates ISBNs" do
-    expect(LibraryStandardNumbers::ISBN.valid?("9781449373320")).to be true
-  end
 end


### PR DESCRIPTION
Also, refactor the tests into their own files, to avoid a rubocop error.